### PR TITLE
fix: masquer sous-titre ARIAHeader dans GeneratingScreen

### DIFF
--- a/src/features/init/components/ARIAHeader.jsx
+++ b/src/features/init/components/ARIAHeader.jsx
@@ -12,7 +12,7 @@
 import { useLocale } from '../../../ariaI18n';
 import { FONT, cinzel, mono } from '../../../shared/theme';
 
-export default function ARIAHeader({ showQuote, lang: langProp, setLang }) {
+export default function ARIAHeader({ showQuote, showSubtitle = true, lang: langProp, setLang }) {
   const { lang: localeLang } = useLocale();
   const lang = langProp ?? localeLang;
   return (
@@ -42,10 +42,12 @@ export default function ARIAHeader({ showQuote, lang: langProp, setLang }) {
           </div>
         )}
       </div>
-      <div style={{
-        fontFamily: FONT.cinzel, fontSize:'0.50rem', letterSpacing:'0.32em',
-        color:'#3A4A62', marginTop:'0.4rem', whiteSpace:'nowrap',
-      }}>ARCHITECTURE DE RAISONNEMENT INSTITUTIONNEL PAR L'IA</div>
+      {showSubtitle && (
+        <div style={{
+          fontFamily: FONT.cinzel, fontSize:'0.50rem', letterSpacing:'0.32em',
+          color:'#3A4A62', marginTop:'0.4rem', whiteSpace:'nowrap',
+        }}>ARCHITECTURE DE RAISONNEMENT INSTITUTIONNEL PAR L'IA</div>
+      )}
       {showQuote && (
         <p style={{
           fontSize:'0.75rem', color:'#5A6A8A', fontStyle:'italic',

--- a/src/features/init/components/screens/GeneratingScreen.jsx
+++ b/src/features/init/components/screens/GeneratingScreen.jsx
@@ -41,7 +41,7 @@ export default function GeneratingScreen({ progress, msg, background }) {
     // Fallback : barre de progression originale
     return (
         <div style={wrap(false)}>
-        <ARIAHeader showQuote={false} />
+        <ARIAHeader showQuote={false} showSubtitle={false} />
         <div style={{ width:'100%', display:'flex', flexDirection:'column', alignItems:'center', gap:'0.85rem' }}>
         <div style={{
             fontFamily:FONT.mono, fontSize:'0.55rem', letterSpacing:'0.14em',


### PR DESCRIPTION
Le sous-titre \"ARCHITECTURE DE RAISONNEMENT...\" à 0.50rem (11px) apparaissait comme une seconde barre statique au-dessus du worldgen-bar. Nouvelle prop showSubtitle={false} dans GeneratingScreen.